### PR TITLE
chore: GitHub Actions에서 S3 버킷 경로를 env 블록으로 관리하도록 수정

### DIFF
--- a/.github/workflows/backup-s3.yml
+++ b/.github/workflows/backup-s3.yml
@@ -25,6 +25,9 @@ jobs:
   backup_s3_job:
     runs-on: ubuntu-latest
 
+    env:
+      AWS_S3_BUCKET_URL: ${{ secrets.AWS_S3_BUCKET_URL }}
+
     steps:
       - name: 레포지토리 체크아웃
         # actions/checkout@v3 액션을 사용하여 푸시된 코드 전체를 가져옵니다.
@@ -58,4 +61,4 @@ jobs:
           BACKUP_NAME="dailydevq-main-backup-$(date +'%Y%m%d_%H%M%S')-${SHORT_SHA}.zip"
 
           # S3 버킷에 업로드 (백업 전용 디렉터리인 backups/ 아래에 저장)
-          aws s3 cp "$BACKUP_NAME" "AWS_S3_BUCKET_URL/$BACKUP_NAME"
+          aws s3 cp "$BACKUP_NAME" "${AWS_S3_BUCKET_URL%/}/$BACKUP_NAME"


### PR DESCRIPTION
### 개요
GitHub Actions 워크플로(backup-s3.yml)에서 S3 버킷 URL을 env 블록을 활용해 환경 변수로 관리하도록 수정했습니다. 

### 변경사항
- env 블록에서 AWS_S3_BUCKET_URL을 받아와 업로드 경로로 사용
- 문자열 결합 시 슬래시 중복 제거 위해 '%/' 구문 적용
- 이전에는 하드코딩된 경로를 사용했으나, Secrets를 통한 값 주입으로 재사용성과 유연성 향상

### 테스트 및 검증
- Actions 실행 후 압축된 파일이 정상적으로 S3의 backups 디렉터리에 업로드되는지 확인
- 로컬 환경 변수 값이 없어도 GitHub Actions에서 Secrets를 통해 값이 주입되므로 문제없이 동작함

검토 부탁드립니다.